### PR TITLE
Update dlc.txt for nemesis and aquatics species pack

### DIFF
--- a/apps/stellaris/steam_settings/DLC.txt
+++ b/apps/stellaris/steam_settings/DLC.txt
@@ -20,3 +20,7 @@
 844810=Stellaris: Distant Stars Story Pack
 944290=Stellaris: MegaCorp
 1045980=Stellaris: Ancient Relics Story Pack
+1140000=Stellaris: Lithoids Species Pack
+1140001=Stellaris: Federations
+1341520=Stellaris: Necroids Species Pack
+1522090=Stellaris: Nemesis

--- a/apps/stellaris/steam_settings/DLC.txt
+++ b/apps/stellaris/steam_settings/DLC.txt
@@ -24,3 +24,4 @@
 1140001=Stellaris: Federations
 1341520=Stellaris: Necroids Species Pack
 1522090=Stellaris: Nemesis
+1749080=Stellaris: Aquatics Species Pack


### PR DESCRIPTION
As brch-cndy stated in his pull request. Federations necroids and lithoids work, so they should be in DLC.txt. I also added nemesis and aquatics as they have been tested and work too.